### PR TITLE
Add churn prediction model

### DIFF
--- a/08_onlyfans_model/README.md
+++ b/08_onlyfans_model/README.md
@@ -1,0 +1,3 @@
+# OnlyFans Churn Prediction Model
+
+This module contains a simple example of training a machine learning model to predict subscriber churn using synthetic data. The `train_model.py` script generates sample data and trains a logistic regression model.

--- a/08_onlyfans_model/train_model.py
+++ b/08_onlyfans_model/train_model.py
@@ -1,0 +1,31 @@
+import os
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+import numpy as np
+
+def train_model(data_path: str) -> LogisticRegression:
+    """Train a churn prediction model on the provided CSV dataset."""
+    df = pd.read_csv(data_path)
+    X = df.drop('churned', axis=1)
+    y = df['churned']
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    model = LogisticRegression(max_iter=200)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    print('Accuracy:', accuracy_score(y_test, preds))
+    return model
+
+if __name__ == "__main__":
+    sample_file = 'sample_churn_data.csv'
+    if not os.path.exists(sample_file):
+        np.random.seed(42)
+        df = pd.DataFrame({
+            'messages_sent': np.random.randint(1, 50, 100),
+            'tips_received': np.random.randint(0, 20, 100),
+            'days_inactive': np.random.randint(0, 30, 100),
+            'churned': np.random.randint(0, 2, 100)
+        })
+        df.to_csv(sample_file, index=False)
+    train_model(sample_file)

--- a/aiClient.py
+++ b/aiClient.py
@@ -1,0 +1,9 @@
+"""Minimal AI client used for unit tests."""
+
+def format_prompt(text: str) -> str:
+    """Return a formatted prompt string."""
+    return f"User: {text}\nAI:"
+
+def generate_response(text: str) -> str:
+    """Return a canned response for demonstration."""
+    return "Sure, I'd be happy to help with that."


### PR DESCRIPTION
## Summary
- add an example churn prediction model module
- provide a minimal AI client for tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a79a776408331b83dce0a437ec966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a churn prediction model example, including a script to train a logistic regression model on synthetic subscriber data.
  - Added a sample README describing the churn prediction module and its usage.
  - Added a minimal AI client with prompt formatting and fixed response generation for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->