### PR TITLE
Fix tests and add publish service

### DIFF
--- a/02_ai_chat_persona/tests/response_tone.test.py
+++ b/02_ai_chat_persona/tests/response_tone.test.py
@@ -1,6 +1,15 @@
 # response_tone.test.py
 
 import unittest
+import sys
+from pathlib import Path
+
+# Add repo root to path so the aiClient module is discoverable when tests are
+# executed from this nested directory.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from aiClient import generate_response
 
 class TestResponseTone(unittest.TestCase):

--- a/03_scheduling_automation/README.md
+++ b/03_scheduling_automation/README.md
@@ -6,8 +6,11 @@ This module handles scheduling posts to OnlyFans (and optionally Hootsuite).
 - `scheduler.js` - Core scheduler logic.
 - `config/` - Configuration files (times, retries, API keys).
 - `docs/` - API specs and architecture diagrams.
+- `publishService.js` - Helper that publishes posts to OnlyFans or Hootsuite.
 
 ## Getting Started
 1. Fill in `config/hootsuite_credentials.json` with your Hootsuite API keys.
 2. Edit `config/scheduler.config.js` to set default posting windows.
 3. Run `node scheduler.js` to launch the scheduler.
+4. `publishService.js` is used internally by the scheduler to post content; edit
+   it if you need to integrate with additional platforms.

--- a/03_scheduling_automation/publishService.js
+++ b/03_scheduling_automation/publishService.js
@@ -1,0 +1,27 @@
+// publishService.js
+// Simple service for posting content to OnlyFans or via automation.
+// This stub logs posts and simulates an API call. In a real implementation,
+// it would authenticate with the OnlyFans API or automation tool.
+
+const axios = require('axios');
+const config = require('./config/scheduler.config');
+
+/**
+ * Publish a post using the configured endpoint.
+ * @param {Object} post - Post object containing content and metadata.
+ */
+async function publishPost(post) {
+  // For now we just log the post and mimic an API call.
+  try {
+    console.log('Publishing post:', post);
+    if (post.platform === 'hootsuite') {
+      await axios.post(config.hootsuiteEndpoint, post);
+    }
+    // OnlyFans publishing would go here.
+  } catch (err) {
+    console.error('Failed to publish post', err.message);
+    throw err;
+  }
+}
+
+module.exports = { publishPost };

--- a/common/utils/pricing.js
+++ b/common/utils/pricing.js
@@ -1,0 +1,7 @@
+// Utility for basic price calculations used in tests.
+function calculatePrice(basePrice, discountRate = 0) {
+  const price = basePrice * (1 - discountRate);
+  return Math.round(price);
+}
+
+module.exports = { calculatePrice };

--- a/tests/unit/test_chat_persona_format.py
+++ b/tests/unit/test_chat_persona_format.py
@@ -1,6 +1,15 @@
 # test_chat_persona_format.py
 
 import unittest
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path so aiClient can be imported when tests
+# are run from subdirectories or CI environments.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from aiClient import format_prompt
 
 class TestChatPersonaFormat(unittest.TestCase):


### PR DESCRIPTION
## Summary
- ensure Python tests can import aiClient module
- stub out `publishService.js` used by scheduler
- document `publishService.js` in scheduler README
- add simple pricing utility for Node unit tests

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `02_ai_chat_persona` *(fails: Could not read package.json)*
- `npm test` in `03_scheduling_automation/browser_automation_service` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a90a5c18083319ccf163b08a21eb0