### PR TITLE
Fix price calculation rounding

### DIFF
--- a/common/utils/pricing.js
+++ b/common/utils/pricing.js
@@ -1,7 +1,9 @@
 // Utility for basic price calculations used in tests.
+// Returns price in *cents* to avoid FP rounding issues.
 function calculatePrice(basePrice, discountRate = 0) {
-  const price = basePrice * (1 - discountRate);
-  return Math.round(price);
+  const basePriceCents = Math.round(basePrice * 100);
+  const discountedCents = Math.round(basePriceCents * (1 - discountRate));
+  return discountedCents; // caller can divide by 100 when displaying
 }
 
 module.exports = { calculatePrice };

--- a/tests/unit/test_price_calculation.js
+++ b/tests/unit/test_price_calculation.js
@@ -8,7 +8,7 @@ const { calculatePrice } = require('../../common/utils/pricing');
 
 try {
   const result = calculatePrice(100, 0.2); // 20% discount
-  assert.strictEqual(result, 80);
+  assert.strictEqual(result, 8000); // result returned in cents
   console.log('Price calculation test passed');
 } catch (err) {
   console.error('Price calculation test failed:', err.message);


### PR DESCRIPTION
## Summary
- avoid float rounding errors in pricing utility
- update unit test for new return type

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b16e15cec83319582dc93fe905aca