### PR TITLE
Add scripts for DM anonymization and A/B evaluation

### DIFF
--- a/02_ai_chat_persona/README.md
+++ b/02_ai_chat_persona/README.md
@@ -4,9 +4,12 @@ This module contains everything to train and test the GPT-based DM persona.
 
 ## Structure
 - `training_scripts/` - Scripts for data prep, cleaning, and fine-tuning.
+- `evaluation/` - Lightweight harness for comparing model variants.
 - `tests/` - Unit and integration tests for persona outputs.
 
 ## Getting Started
-1. Run `node training_scripts/preprocess_dms.js` to clean raw DM logs.
-2. Run `node training_scripts/fine_tune.js` to start fine-tuning.
-3. Use `npm test` in this folder to verify tests in `tests/`.
+1. Run `python training_scripts/anonymize_archive.py` to scrub personal data.
+2. Run `node training_scripts/preprocess_dms.js` to create a JSONL dataset.
+3. Run `node training_scripts/fine_tune.js` to start fine-tuning.
+4. Optionally run `python evaluation/ab_test.py baseline.jsonl candidate.jsonl` to score a new model.
+5. Use `npm test` in this folder to verify tests in `tests/`.

--- a/02_ai_chat_persona/evaluation/ab_test.py
+++ b/02_ai_chat_persona/evaluation/ab_test.py
@@ -1,0 +1,34 @@
+"""Simple A/B evaluation harness for DM responses."""
+import argparse
+import json
+
+
+def load_jsonl(path):
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def evaluate(baseline_path, candidate_path):
+    baseline = load_jsonl(baseline_path)
+    candidate = load_jsonl(candidate_path)
+    pairs = zip(baseline, candidate)
+    wins = 0
+    total = 0
+    for b, c in pairs:
+        if len(c.get("completion", "")) < len(b.get("completion", "")):
+            wins += 1
+        total += 1
+    return wins / total if total else 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run simple pairwise evaluation")
+    parser.add_argument("baseline", help="Baseline JSONL file")
+    parser.add_argument("candidate", help="Candidate JSONL file")
+    args = parser.parse_args()
+    win_rate = evaluate(args.baseline, args.candidate)
+    print(f"Candidate win rate: {win_rate:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/02_ai_chat_persona/training_scripts/anonymize_archive.py
+++ b/02_ai_chat_persona/training_scripts/anonymize_archive.py
@@ -1,0 +1,33 @@
+"""Anonymize raw DM archive by scrubbing simple PII patterns."""
+import csv
+import json
+import re
+
+PII_PATTERNS = [
+    r"@\w+",                       # handles
+    r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b"  # phone numbers
+]
+
+def scrub(text: str) -> str:
+    for pat in PII_PATTERNS:
+        text = re.sub(pat, "[REDACTED]", text)
+    return text
+
+
+def main():
+    messages = []
+    with open("full_dm_archive_raw.csv", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            inbound = scrub(row.get("inbound", ""))
+            response = scrub(row.get("response", ""))
+            messages.append({"inbound": inbound, "response": response})
+
+    out_path = "full_dm_archive_cleaned.json"
+    with open(out_path, "w") as f:
+        json.dump({"messages": messages}, f, indent=2)
+    print(f"Wrote {len(messages)} messages to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_anonymize_archive.py
+++ b/tests/test_anonymize_archive.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / '02_ai_chat_persona' / 'training_scripts'))
+
+from anonymize_archive import scrub
+
+def test_scrub_replaces_handle_and_phone():
+    text = "Hey @john call me at 555-123-4567"
+    result = scrub(text)
+    assert "@" not in result
+    assert "555" not in result


### PR DESCRIPTION
## Summary
- add `anonymize_archive.py` to scrub PII from DM logs
- add `ab_test.py` to compare model variants
- document new scripts in `02_ai_chat_persona/README.md`
- add a unit test for the anonymization helper

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1859559083318bb3f7b810f1c6b5