### PR TITLE
Add evaluation metrics harness

### DIFF
--- a/02_ai_chat_persona/README.md
+++ b/02_ai_chat_persona/README.md
@@ -4,9 +4,17 @@ This module contains everything to train and test the GPT-based DM persona.
 
 ## Structure
 - `training_scripts/` - Scripts for data prep, cleaning, and fine-tuning.
+- `evaluation/` - Tools for pairwise A/B tests and metric tracking.
 - `tests/` - Unit and integration tests for persona outputs.
 
 ## Getting Started
-1. Run `node training_scripts/preprocess_dms.js` to clean raw DM logs.
-2. Run `node training_scripts/fine_tune.js` to start fine-tuning.
-3. Use `npm test` in this folder to verify tests in `tests/`.
+1. Run `python training_scripts/anonymize_archive.py` to scrub personal data.
+2. Run `node training_scripts/preprocess_dms.js` to create a JSONL dataset.
+3. Run `node training_scripts/fine_tune.js` to start fine-tuning.
+4. Optionally run `python evaluation/ab_test.py --baseline baseline.jsonl --candidate candidate.jsonl --out_pairs eval_pairs.json` to generate pairs for rating.
+5. After you gather ratings and engagement stats, run `python evaluation/ab_test.py --ratings ratings.json --engagement engagement.json` to compute metrics.
+6. Use `npm test` in this folder to verify tests in `tests/`.
+
+## Evaluation Metrics
+- **Fluency & Brand Fit:** 1–5 human ratings for each response pair.
+- **Engagement Lift:** Delta in click-through or reply rates vs. the baseline.

--- a/02_ai_chat_persona/evaluation/ab_test.py
+++ b/02_ai_chat_persona/evaluation/ab_test.py
@@ -1,0 +1,79 @@
+"""Evaluation harness for pairwise A/B tests."""
+import argparse
+import json
+from typing import List, Dict, Tuple
+
+
+def load_jsonl(path: str) -> List[Dict]:
+    """Load a JSONL file into a list of dictionaries."""
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def generate_pairs(baseline_path: str, candidate_path: str, out_path: str) -> None:
+    """Create a JSON file with paired baseline and candidate completions."""
+    baseline = load_jsonl(baseline_path)
+    candidate = load_jsonl(candidate_path)
+    pairs = []
+    for b, c in zip(baseline, candidate):
+        pairs.append({
+            "prompt": b.get("prompt"),
+            "baseline": b.get("completion"),
+            "candidate": c.get("completion"),
+        })
+    with open(out_path, "w") as f:
+        json.dump(pairs, f, indent=2)
+
+
+def average(values: List[int]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def evaluate_ratings(ratings_path: str) -> Tuple[float, float]:
+    """Return average candidate and baseline scores from a ratings JSON."""
+    with open(ratings_path) as f:
+        rows = json.load(f)
+    base_scores = [r["baseline_rating"] for r in rows]
+    cand_scores = [r["candidate_rating"] for r in rows]
+    return average(cand_scores), average(base_scores)
+
+
+def evaluate_engagement(metrics_path: str) -> Tuple[float, float]:
+    """Compute engagement deltas from a metrics JSON file."""
+    with open(metrics_path) as f:
+        data = json.load(f)
+    base = data["baseline"]
+    cand = data["candidate"]
+    base_ctr = base["clicks"] / base["impressions"]
+    cand_ctr = cand["clicks"] / cand["impressions"]
+    base_reply = base["replies"] / base["impressions"]
+    cand_reply = cand["replies"] / cand["impressions"]
+    return cand_ctr - base_ctr, cand_reply - base_reply
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute A/B evaluation metrics")
+    parser.add_argument("--baseline", help="Baseline JSONL responses")
+    parser.add_argument("--candidate", help="Candidate JSONL responses")
+    parser.add_argument("--out_pairs", help="Path to write paired prompts")
+    parser.add_argument("--ratings", help="JSON file with human ratings")
+    parser.add_argument("--engagement", help="JSON file with engagement metrics")
+    args = parser.parse_args()
+
+    if args.out_pairs and args.baseline and args.candidate:
+        generate_pairs(args.baseline, args.candidate, args.out_pairs)
+        print(f"Wrote evaluation pairs to {args.out_pairs}")
+
+    if args.ratings:
+        cand_avg, base_avg = evaluate_ratings(args.ratings)
+        print(f"Average candidate rating: {cand_avg:.2f}")
+        print(f"Average baseline rating: {base_avg:.2f}")
+
+    if args.engagement:
+        click_lift, reply_lift = evaluate_engagement(args.engagement)
+        print(f"Click-through lift: {click_lift:.2%}")
+        print(f"Reply-rate lift: {reply_lift:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/02_ai_chat_persona/training_scripts/anonymize_archive.py
+++ b/02_ai_chat_persona/training_scripts/anonymize_archive.py
@@ -1,0 +1,33 @@
+"""Anonymize raw DM archive by scrubbing simple PII patterns."""
+import csv
+import json
+import re
+
+PII_PATTERNS = [
+    r"@\w+",                       # handles
+    r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b"  # phone numbers
+]
+
+def scrub(text: str) -> str:
+    for pat in PII_PATTERNS:
+        text = re.sub(pat, "[REDACTED]", text)
+    return text
+
+
+def main():
+    messages = []
+    with open("full_dm_archive_raw.csv", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            inbound = scrub(row.get("inbound", ""))
+            response = scrub(row.get("response", ""))
+            messages.append({"inbound": inbound, "response": response})
+
+    out_path = "full_dm_archive_cleaned.json"
+    with open(out_path, "w") as f:
+        json.dump({"messages": messages}, f, indent=2)
+    print(f"Wrote {len(messages)} messages to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ab_test.py
+++ b/tests/test_ab_test.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / '02_ai_chat_persona' / 'evaluation'))
+
+from ab_test import evaluate_ratings, evaluate_engagement
+
+
+def test_evaluate_ratings():
+    data = [
+        {"baseline_rating": 3, "candidate_rating": 4},
+        {"baseline_rating": 2, "candidate_rating": 5},
+    ]
+    path = ROOT / 'tmp_ratings.json'
+    with open(path, 'w') as f:
+        json.dump(data, f)
+    cand, base = evaluate_ratings(str(path))
+    assert cand == 4.5
+    assert base == 2.5
+    path.unlink()
+
+
+def test_evaluate_engagement():
+    metrics = {
+        "baseline": {"impressions": 100, "clicks": 10, "replies": 5},
+        "candidate": {"impressions": 100, "clicks": 15, "replies": 8},
+    }
+    path = ROOT / 'tmp_engagement.json'
+    with open(path, 'w') as f:
+        json.dump(metrics, f)
+    click_lift, reply_lift = evaluate_engagement(str(path))
+    assert abs(click_lift - 0.05) < 1e-6
+    assert abs(reply_lift - 0.03) < 1e-6
+    path.unlink()

--- a/tests/test_anonymize_archive.py
+++ b/tests/test_anonymize_archive.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / '02_ai_chat_persona' / 'training_scripts'))
+
+from anonymize_archive import scrub
+
+def test_scrub_replaces_handle_and_phone():
+    text = "Hey @john call me at 555-123-4567"
+    result = scrub(text)
+    assert "@" not in result
+    assert "555" not in result


### PR DESCRIPTION
## Summary
- refine `evaluation/ab_test.py` to calculate human ratings and engagement lift
- document evaluation metrics and new workflow in the persona README
- add unit tests for the updated evaluation helpers

## Testing
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b1859559083318bb3f7b810f1c6b5