### PR TITLE
Apply CodeRabbit fixes to pricing and publish utilities

### DIFF
--- a/03_scheduling_automation/browser_automation_service/backend/test-apply-schema.js
+++ b/03_scheduling_automation/browser_automation_service/backend/test-apply-schema.js
@@ -1,8 +1,13 @@
 // backend/test-apply-schema.js
 import { exec } from 'child_process';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
-// Run apply-schema.js from this backend directory
-exec('node backend/apply-schema.js', (err, stdout, stderr) => {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const script = resolve(__dirname, 'apply-schema.js');
+
+// Run apply-schema.js from this backend directory regardless of CWD
+exec(`node ${script}`, (err, stdout, stderr) => {
   if (err) {
     console.error('Script failed:', stderr);
     process.exit(1);

--- a/03_scheduling_automation/publishService.js
+++ b/03_scheduling_automation/publishService.js
@@ -14,10 +14,14 @@ async function publishPost(post) {
   // For now we just log the post and mimic an API call.
   try {
     console.log('Publishing post:', post);
-    if (post.platform === 'hootsuite') {
-      await axios.post(config.hootsuiteEndpoint, post);
+    switch (post.platform) {
+      case 'hootsuite':
+        return await axios.post(config.hootsuiteEndpoint, post);
+      case 'onlyfans':
+        throw new Error('OnlyFans publishing not yet implemented');
+      default:
+        throw new Error(`Unsupported platform: ${post.platform}`);
     }
-    // OnlyFans publishing would go here.
   } catch (err) {
     console.error('Failed to publish post', err.message);
     throw err;

--- a/common/utils/pricing.js
+++ b/common/utils/pricing.js
@@ -1,9 +1,9 @@
 // Utility for basic price calculations used in tests.
-// Returns price in *cents* to avoid FP rounding issues.
-function calculatePrice(basePrice, discountRate = 0) {
-  const basePriceCents = Math.round(basePrice * 100);
-  const discountedCents = Math.round(basePriceCents * (1 - discountRate));
-  return discountedCents; // caller can divide by 100 when displaying
+// Accepts the base price in **cents** and returns the discounted price in
+// cents as well to avoid floating point precision issues.
+function calculatePrice(basePriceCents, discountRate = 0) {
+  const discounted = Math.round(basePriceCents * (1 - discountRate));
+  return discounted; // caller can divide by 100 when displaying
 }
 
 module.exports = { calculatePrice };

--- a/tests/unit/test_price_calculation.js
+++ b/tests/unit/test_price_calculation.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const { calculatePrice } = require('../../common/utils/pricing');
 
 try {
-  const result = calculatePrice(100, 0.2); // 20% discount
+  const result = calculatePrice(10000, 0.2); // 20% discount on $100 -> 10000 cents
   assert.strictEqual(result, 8000); // result returned in cents
   console.log('Price calculation test passed');
 } catch (err) {


### PR DESCRIPTION
## Summary
- make pricing util take cents directly
- return a response from `publishPost`
- use an absolute path in the backend schema test
- update JS test for new `calculatePrice` API

## Testing
- `pytest -q`
- `npm test`
- `npm test` in `02_ai_chat_persona` *(fails: mocha not installed)*
- `npm test` in `03_scheduling_automation/browser_automation_service` *(fails: better-sqlite3 ELF error)*

------
https://chatgpt.com/codex/tasks/task_e_684b1ded72d08331902f7afa33cfb06b