### PR TITLE
Add content generation pipeline docs

### DIFF
--- a/03_scheduling_automation/docs/scheduler_feature_spec.md
+++ b/03_scheduling_automation/docs/scheduler_feature_spec.md
@@ -7,3 +7,35 @@ This document outlines the major components of the scheduler interface. Detailed
 - Caption input with character count
 - Time scheduling with timezone awareness
 - Cross-platform posting (OnlyFans, Hootsuite)
+
+## Workflow Details
+
+### 1. Date/Time Selection
+- Users begin on the **Schedule a Post** screen showing a calendar view.
+- Selecting a date opens a time picker with hour, minute, and timezone fields.
+- Shortcuts include *Today*, *Next Available*, and *Same Time Tomorrow*.
+- Dots indicate existing scheduled posts; hovering reveals a quick preview.
+
+### 2. Media Attachment
+- In the Post Editor, the left pane is a drop zone for uploading images or video.
+- Thumbnails appear in a horizontal carousel; clicking one opens basic crop/trim controls.
+- Each file shows an upload progress bar and a checkmark when complete.
+
+### 3. Caption & Hashtag Editing
+- The right pane contains a text area with live character count.
+- A button below fetches AI-generated caption and hashtag suggestions.
+- Suggested hashtags are presented with checkboxes; selected tags update a total count.
+
+### 4. Final Actions
+- Buttons at the bottom allow **Save as Draft** or **Schedule**.
+- A confirmation dialog summarizes the date/time, attached media, and caption before finalizing.
+- Errors from the API are displayed inline with guidance on next steps.
+
+## API Integration Notes
+
+The scheduler UI relies on the endpoints defined in
+[scheduler_api_spec.md](scheduler_api_spec.md) for creating, updating, and
+canceling scheduled posts. Environment variables such as `OF_API_KEY` and
+`HOOTSUITE_TOKEN` (see [`common/env.example`](../../common/env.example)) must be
+available for real posting. When credentials are missing, the UI should disable
+the **Schedule** button and prompt users to contact the API team.

--- a/04_content_generation/README.md
+++ b/04_content_generation/README.md
@@ -5,9 +5,14 @@ This module manages AI-driven image/video enhancements and caption creation.
 ## Structure
 - `prompt_templates/` - Library of prompt templates for different asset types.
 - `pipeline_prototype/` - Proof-of-concept scripts to generate content.
+- `pipeline_spec.md` - Overview of the generation workflow and required env vars.
 - `assets/` - Sample output files to verify pipeline.
 
 ## Getting Started
 1. Choose a prompt from `prompt_templates/`.
 2. Run `node pipeline_prototype/generate_image.js` to generate an image.
-3. Verify output in `assets/`.
+3. Run `python pipeline_prototype/caption_generator.py` to create a caption.
+4. Verify output files in `assets/`.
+
+Environment variables such as `IMAGE_ENGINE_API_KEY`, `VIDEO_ENGINE_API_KEY`,
+and `OPENAI_API_KEY` must be set (see `pipeline_spec.md`).

--- a/04_content_generation/pipeline_spec.md
+++ b/04_content_generation/pipeline_spec.md
@@ -1,0 +1,34 @@
+# Content Generation Pipeline
+
+This document describes how the prototype scripts work together to create images, video clips, and captions.
+
+## Workflow Steps
+
+1. **Select a Prompt**
+   - Choose or craft a prompt in `prompt_templates/`.
+
+2. **Generate an Image**
+   - Run `node pipeline_prototype/generate_image.js`.
+   - Requires `IMAGE_ENGINE_API_KEY` for the external image engine API.
+   - Output saved to `assets/output_cover.png`.
+
+3. **Generate a Video**
+   - Run `bash pipeline_prototype/generate_video.sh`.
+   - If integrating with an external service, set `VIDEO_ENGINE_API_KEY`.
+   - Demo script uses FFmpeg to create `assets/output_teaser.mp4`.
+
+4. **Create a Caption**
+   - Import `generate_caption` from `pipeline_prototype/caption_generator.py` or run the script directly.
+   - Uses `OPENAI_API_KEY` when wired to a live LLM.
+
+## Environment Variables
+
+Add these variables to `common/env.example` and load them before running the scripts:
+
+```
+IMAGE_ENGINE_API_KEY=your_image_api_key
+VIDEO_ENGINE_API_KEY=your_video_api_key
+OPENAI_API_KEY=your_openai_key
+```
+
+These values enable API calls for image, video, and caption generation.

--- a/common/env.example
+++ b/common/env.example
@@ -1,3 +1,7 @@
 OF_API_KEY=your_of_key
 HOOTSUITE_TOKEN=your_token
 DB_URL=postgres://user:pass@localhost:5432/of_ai
+IMAGE_ENGINE_API_KEY=your_image_api_key
+VIDEO_ENGINE_API_KEY=your_video_api_key
+OPENAI_API_KEY=your_openai_key
+

--- a/tests/unit/test_caption_generator.py
+++ b/tests/unit/test_caption_generator.py
@@ -1,0 +1,19 @@
+import unittest
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CAPTION_PATH = ROOT / '04_content_generation' / 'pipeline_prototype'
+if str(CAPTION_PATH) not in sys.path:
+    sys.path.insert(0, str(CAPTION_PATH))
+
+from caption_generator import generate_caption
+
+class TestCaptionGenerator(unittest.TestCase):
+    def test_generate_caption_includes_context(self):
+        result = generate_caption('beach day')
+        self.assertIn('beach day', result)
+        self.assertTrue(result.startswith('Serving looks'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- document content generation workflow and env vars
- reference env vars in README
- extend example `.env` file with image/video/LLM tokens
- add caption generator unit test

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2b7d1bb08331a98013e04ed3baff