### PR TITLE
Add chatRouter implementation for persona tests

### DIFF
--- a/02_ai_chat_persona/training_scripts/chatRouter.js
+++ b/02_ai_chat_persona/training_scripts/chatRouter.js
@@ -1,0 +1,7 @@
+// Simple chat router used for tests
+// Exports generateResponse which returns a friendly reply.
+async function generateResponse(message) {
+  return `Hey there! Thanks for reaching out: ${message}`;
+}
+
+module.exports = { generateResponse };


### PR DESCRIPTION
## Summary
- implement `chatRouter.js` under training scripts with a simple `generateResponse`
- enables persona style test to resolve module path

## Testing
- `npm test` in the persona package
- `npm test` in repo root
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b32ec7d4483318dd7068389088719