### PR TITLE
Fix comment syntax in generate_image.js

### DIFF
--- a/04_content_generation/pipeline_prototype/generate_image.js
+++ b/04_content_generation/pipeline_prototype/generate_image.js
@@ -10,7 +10,7 @@ require('dotenv').config();
 async function generate() {
   const prompt = fs.readFileSync('../prompt_templates/cover_image_prompts.md', 'utf-8').split('\n')[0];
 
-  # Dummy API call structure; replace with actual SDK or HTTP request
+  // Dummy API call structure; replace with actual SDK or HTTP request
   const response = await axios.post(
     'https://api.your-image-engine.com/v1/generate',
     { prompt },


### PR DESCRIPTION
## Summary
- replace `#` comment with `//` in `generate_image.js`

## Testing
- `npm test`
- `node --check 04_content_generation/pipeline_prototype/generate_image.js`


------
https://chatgpt.com/codex/tasks/task_e_684b330518a48331a749417ae0db3717