### PR TITLE
Add evaluation metrics and enhanced anonymizer

### DIFF
--- a/02_ai_chat_persona/evaluation/ab_test.py
+++ b/02_ai_chat_persona/evaluation/ab_test.py
@@ -1,33 +1,89 @@
-"""Simple A/B evaluation harness for DM responses."""
+"""Evaluation harness for pairwise A/B tests."""
+from typing import List, Dict, Tuple
+
 import argparse
 import json
 
 
-def load_jsonl(path):
+def load_jsonl(path: str) -> List[Dict]:
+    """Load a JSONL file into a list of dictionaries."""
     with open(path) as f:
         return [json.loads(line) for line in f if line.strip()]
 
 
-def evaluate(baseline_path, candidate_path):
+def generate_pairs(baseline_path: str, candidate_path: str, out_path: str) -> None:
+    """Create a JSON file with paired baseline and candidate completions."""
     baseline = load_jsonl(baseline_path)
     candidate = load_jsonl(candidate_path)
-    pairs = zip(baseline, candidate)
-    wins = 0
-    total = 0
-    for b, c in pairs:
-        if len(c.get("completion", "")) < len(b.get("completion", "")):
-            wins += 1
-        total += 1
-    return wins / total if total else 0.0
+
+    if len(baseline) != len(candidate):
+        raise ValueError("Baseline and candidate sets must have equal length")
+
+    pairs = []
+    for b, c in zip(baseline, candidate):
+        pairs.append({
+            "prompt": b.get("prompt"),
+            "baseline": b.get("completion"),
+            "candidate": c.get("completion"),
+        })
+    with open(out_path, "w") as f:
+        json.dump(pairs, f, indent=2)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Run simple pairwise evaluation")
-    parser.add_argument("baseline", help="Baseline JSONL file")
-    parser.add_argument("candidate", help="Candidate JSONL file")
+def average(values: List[float]) -> float:
+    """Return the arithmetic mean of a list of numbers."""
+    return sum(values) / len(values) if values else 0.0
+
+
+def evaluate_ratings(ratings_path: str) -> Tuple[float, float]:
+    """Return average candidate and baseline scores from a ratings JSON."""
+    with open(ratings_path) as f:
+        rows = json.load(f)
+    base_scores = [r["baseline_rating"] for r in rows]
+    cand_scores = [r["candidate_rating"] for r in rows]
+    return average(cand_scores), average(base_scores)
+
+
+def _rate(part: int, total: int) -> float:
+    """Safe division returning zero when total is zero."""
+    return part / total if total else 0.0
+
+
+def evaluate_engagement(metrics_path: str) -> Tuple[float, float]:
+    """Compute engagement deltas from a metrics JSON file."""
+    with open(metrics_path) as f:
+        data = json.load(f)
+    base = data["baseline"]
+    cand = data["candidate"]
+    base_ctr = _rate(base["clicks"], base["impressions"])
+    cand_ctr = _rate(cand["clicks"], cand["impressions"])
+    base_reply = _rate(base["replies"], base["impressions"])
+    cand_reply = _rate(cand["replies"], cand["impressions"])
+    return cand_ctr - base_ctr, cand_reply - base_reply
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute A/B evaluation metrics")
+    parser.add_argument("--baseline", help="Baseline JSONL responses")
+    parser.add_argument("--candidate", help="Candidate JSONL responses")
+    parser.add_argument("--out_pairs", help="Path to write paired prompts")
+    parser.add_argument("--ratings", help="JSON file with human ratings")
+    parser.add_argument("--engagement", help="JSON file with engagement metrics")
     args = parser.parse_args()
-    win_rate = evaluate(args.baseline, args.candidate)
-    print(f"Candidate win rate: {win_rate:.2%}")
+
+    if args.out_pairs and args.baseline and args.candidate:
+        generate_pairs(args.baseline, args.candidate, args.out_pairs)
+        print(f"Wrote evaluation pairs to {args.out_pairs}")
+
+    if args.ratings:
+        cand_avg, base_avg = evaluate_ratings(args.ratings)
+        print(f"Average candidate rating: {cand_avg:.2f}")
+        print(f"Average baseline rating: {base_avg:.2f}")
+
+    if args.engagement:
+        click_lift, reply_lift = evaluate_engagement(args.engagement)
+        print(f"Click-through lift: {click_lift:.2%}")
+        print(f"Reply-rate lift: {reply_lift:.2%}")
 
 
 if __name__ == "__main__":

--- a/02_ai_chat_persona/training_scripts/anonymize_archive.py
+++ b/02_ai_chat_persona/training_scripts/anonymize_archive.py
@@ -1,33 +1,68 @@
 """Anonymize raw DM archive by scrubbing simple PII patterns."""
+from typing import List, Optional
+
+import argparse
 import csv
 import json
 import re
 
 PII_PATTERNS = [
     r"@\w+",                       # handles
-    r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b"  # phone numbers
+    r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b",  # phone numbers
 ]
 
-def scrub(text: str) -> str:
-    for pat in PII_PATTERNS:
+
+def load_names(path: Optional[str]) -> List[str]:
+    """Return a list of names from a file if provided."""
+    if not path:
+        return []
+    with open(path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def build_name_pattern(names: List[str]) -> str:
+    """Return a regex that matches any of the given names."""
+    if not names:
+        return r"\b[A-Z][a-z]+\b"
+    escaped = [re.escape(n) for n in names]
+    return r"\b(?:" + "|".join(escaped) + r")\b"
+
+
+def scrub(text: str, patterns: Optional[List[str]] = None) -> str:
+    """Replace any PII patterns in the given text."""
+    if patterns is None:
+        patterns = PII_PATTERNS + [build_name_pattern([])]
+    for pat in patterns:
         text = re.sub(pat, "[REDACTED]", text)
     return text
 
 
-def main():
+def main(in_path: str, out_path: str, names_file: Optional[str] = None) -> None:
+    """Anonymize a CSV archive and write cleaned JSON."""
+    patterns = PII_PATTERNS + [build_name_pattern(load_names(names_file))]
+
     messages = []
-    with open("full_dm_archive_raw.csv", newline="") as f:
+    with open(in_path, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            inbound = scrub(row.get("inbound", ""))
-            response = scrub(row.get("response", ""))
+            inbound = scrub(row.get("inbound", ""), patterns)
+            response = scrub(row.get("response", ""), patterns)
             messages.append({"inbound": inbound, "response": response})
 
-    out_path = "full_dm_archive_cleaned.json"
     with open(out_path, "w") as f:
         json.dump({"messages": messages}, f, indent=2)
     print(f"Wrote {len(messages)} messages to {out_path}")
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Anonymize a DM CSV archive")
+    parser.add_argument("in_csv", help="Raw CSV file")
+    parser.add_argument("out_json", help="Path to write cleaned JSON")
+    parser.add_argument(
+        "--names_file",
+        help="Optional text file with one name per line to scrub",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    main(args.in_csv, args.out_json, args.names_file)

--- a/tests/test_anonymize_archive.py
+++ b/tests/test_anonymize_archive.py
@@ -1,13 +1,35 @@
 import sys
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / '02_ai_chat_persona' / 'training_scripts'))
 
-from anonymize_archive import scrub
+from anonymize_archive import scrub, main
 
 def test_scrub_replaces_handle_and_phone():
     text = "Hey @john call me at 555-123-4567"
     result = scrub(text)
     assert "@" not in result
     assert "555" not in result
+
+
+def test_main_writes_file(tmp_path):
+    csv_path = tmp_path / "in.csv"
+    with open(csv_path, "w") as f:
+        f.write("inbound,response\nHi John,hello\n")
+    out_json = tmp_path / "out.json"
+    main(str(csv_path), str(out_json))
+    assert out_json.exists()
+
+
+def test_names_file(tmp_path):
+    csv_path = tmp_path / "in.csv"
+    with open(csv_path, "w") as f:
+        f.write("inbound,response\nHi Alice,hello\n")
+    names = tmp_path / "names.txt"
+    names.write_text("Alice\n")
+    out_json = tmp_path / "out.json"
+    main(str(csv_path), str(out_json), str(names))
+    data = json.load(open(out_json))
+    assert "Alice" not in data["messages"][0]["inbound"]


### PR DESCRIPTION
## Summary
- extend ab_test.py with metrics for ratings and engagement
- support scrubbing names in anonymize_archive.py
- update anonymize tests for new CLI functions

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684b4e6a425c83318c586223ae7c576e