### PR TITLE
Fix failing backend apply-schema tests

### DIFF
--- a/03_scheduling_automation/browser_automation_service/backend/apply-schema.js
+++ b/03_scheduling_automation/browser_automation_service/backend/apply-schema.js
@@ -1,33 +1,41 @@
 import fs from 'fs';
 import path from 'path';
-import Database from 'better-sqlite3';
+import { fileURLToPath } from 'url';
+import {
+  createDbConnection,
+  runAsync,
+  getAsync,
+  closeDbConnection
+} from './db/db.js';
 
 (async () => {
   try {
-    // Open or create the SQLite database file
-    const dbPath = '/app/logs.db'; // Use absolute path
-    const db = new Database(dbPath);
+    // Initialize SQL.js database in the current directory
+    await createDbConnection(path.resolve('logs.db'));
 
     // Read the schema SQL
-    const schemaPath = path.resolve('db/schema.sql');
+    const schemaPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'schema.sql');
     const schema = fs.readFileSync(schemaPath, 'utf8');
 
     // Execute each statement
     for (const stmt of schema.split(';').map(s => s.trim()).filter(Boolean)) {
-      db.exec(stmt);
+      runAsync(stmt);
     }
 
     // Verify schema version
-    const row = db.prepare('SELECT version FROM schema_version').get();
+    const row = getAsync('SELECT version FROM schema_version');
     if (row && row.version === 1) {
       console.log('✅ Schema applied successfully and version 1 verified.');
     } else {
-      console.error('❌ Schema applied, but version verification FAILED. Found version:', row ? row.version : 'not found');
-      db.close();
+      console.error(
+        '❌ Schema applied, but version verification FAILED. Found version:',
+        row ? row.version : 'not found'
+      );
+      closeDbConnection();
       process.exit(1); // Exit with error if verification fails
     }
 
-    db.close();
+    closeDbConnection();
   } catch (err) {
     console.error('❌ Schema application failed:', err);
     process.exit(1);

--- a/03_scheduling_automation/browser_automation_service/backend/db/db.js
+++ b/03_scheduling_automation/browser_automation_service/backend/db/db.js
@@ -14,6 +14,7 @@ const defaultDbFile = process.env.DB_FILE
 
 let SQL;       // SQL.js module
 let dbInstance;
+let currentDbFile = defaultDbFile;
 
 /**
  * Initialize and return the SQL.js Database in WASM.
@@ -24,7 +25,8 @@ let dbInstance;
 export async function createDbConnection(customPath) {
   const dbFile = customPath || defaultDbFile;
   if (!SQL) {
-    SQL = await initSqlJs({ locateFile: file => `./node_modules/sql.js/dist/${file}` });
+    const locate = file => path.join(__dirname, '../node_modules/sql.js/dist', file);
+    SQL = await initSqlJs({ locateFile: locate });
   }
 
   let filebuffer = new Uint8Array();
@@ -33,6 +35,7 @@ export async function createDbConnection(customPath) {
   }
 
   dbInstance = new SQL.Database(filebuffer);
+  currentDbFile = dbFile;
   return dbInstance;
 }
 
@@ -43,7 +46,7 @@ export async function createDbConnection(customPath) {
 export function saveDb(customPath) {
   if (!dbInstance) return;
   const data = dbInstance.export();
-  const outFile = customPath || defaultDbFile;
+  const outFile = customPath || currentDbFile;
   fs.writeFileSync(outFile, Buffer.from(data));
 }
 

--- a/03_scheduling_automation/browser_automation_service/backend/schema.sql
+++ b/03_scheduling_automation/browser_automation_service/backend/schema.sql
@@ -7,3 +7,22 @@ CREATE TABLE IF NOT EXISTS logs (
   error TEXT,
   captchaDetected INTEGER DEFAULT 0
 );
+
+CREATE TABLE IF NOT EXISTS jobs (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL DEFAULT 'queued',
+  created_at TEXT NOT NULL,
+  updated_at TEXT,
+  result TEXT,
+  error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS schedules (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id TEXT NOT NULL,
+  run_at TEXT NOT NULL,
+  status TEXT DEFAULT 'pending'
+);
+
+CREATE TABLE IF NOT EXISTS schema_version (version INTEGER);
+INSERT OR REPLACE INTO schema_version(rowid, version) VALUES (1, 1);


### PR DESCRIPTION
## Summary
- use sql.js for portable DB access
- track DB path in `db.js`
- update apply-schema scripts to run with sql.js
- add required tables to `schema.sql`

## Testing
- `pytest -q`
- `npm test --silent`
- `cd 02_ai_chat_persona && npm test --silent`
- `cd 03_scheduling_automation/browser_automation_service && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b4fa947d88331b1226fa38b7b64fb