### PR TITLE
Fix connection test

### DIFF
--- a/03_scheduling_automation/of_api_connection_test.py
+++ b/03_scheduling_automation/of_api_connection_test.py
@@ -1,4 +1,4 @@
 # Stub: Connect to OnlyFans API
 def test_connection():
     print('Connecting to OF Sandbox...')
-    return True
+    assert True


### PR DESCRIPTION
## Summary
- fix of_api_connection_test stub to avoid pytest warning

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684b5fd8f9bc83319580888cbe053f1a