### PR TITLE
Fix environment variable for DB

### DIFF
--- a/common/env.example
+++ b/common/env.example
@@ -1,6 +1,6 @@
 OF_API_KEY=your_of_key
 HOOTSUITE_TOKEN=your_token
-DB_URL=postgres://user:pass@localhost:5432/of_ai
+DATABASE_URL=postgres://user:pass@localhost:5432/of_ai
 IMAGE_ENGINE_API_KEY=your_image_api_key
 VIDEO_ENGINE_API_KEY=your_video_api_key
 OPENAI_API_KEY=your_openai_key


### PR DESCRIPTION
## Summary
- correct database URL environment variable name

## Testing
- `pytest -q`
- `npm test --silent`
- `(cd 02_ai_chat_persona && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_e_684b6c7f5d408331968e8e7d028aafb5