### PR TITLE
Add onboarding workflow script

### DIFF
--- a/05_crm_subscriber_management/README.md
+++ b/05_crm_subscriber_management/README.md
@@ -9,3 +9,9 @@ This module contains message templates and workflows for subscriber tiers.
 ## Getting Started
 1. Edit or add new templates in `message_templates/`.
 2. Integrate these templates into your CRM automation scripts.
+
+## Example Workflow
+
+`crm/onboarding.py` is a simple Python script that loads the segmentation rules
+and tier definitions to send a tier-specific welcome message for new
+subscribers. Run it from this folder to see console output.

--- a/05_crm_subscriber_management/crm/onboarding.py
+++ b/05_crm_subscriber_management/crm/onboarding.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+import yaml
+import argparse
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+RULES_FILE = BASE_DIR / "segmentation_rules.json"
+TIERS_FILE = BASE_DIR / "tier_definitions.yaml"
+TEMPLATES_DIR = BASE_DIR / "message_templates"
+
+
+def load_rules():
+    with open(RULES_FILE, 'r') as f:
+        data = json.load(f)
+    return data.get('rules', [])
+
+
+def load_tiers():
+    with open(TIERS_FILE, 'r') as f:
+        data = yaml.safe_load(f)
+    return data.get('tiers', [])
+
+
+def parse_condition(value_str, actual):
+    """Evaluate a simple condition like '<7' or '>100'."""
+    if value_str.startswith('<'):
+        return actual < float(value_str[1:])
+    if value_str.startswith('>'):
+        return actual > float(value_str[1:])
+    return str(actual) == str(value_str)
+
+
+def assign_segment(user, rules):
+    for rule in rules:
+        segment = rule.get('segment')
+        conditions = {k: v for k, v in rule.items() if k != 'segment'}
+        matched = True
+        for field, cond in conditions.items():
+            actual = user.get(field)
+            if actual is None or not parse_condition(cond, actual):
+                matched = False
+                break
+        if matched:
+            return segment
+    return 'Unsegmented'
+
+
+def assign_tier(user, tiers):
+    spend = user.get('total_spend', 0)
+    # Simple heuristic using spend; names come from config
+    tier_order = [t['name'] for t in tiers]
+    if spend > 100 and 'Ultra' in tier_order:
+        return 'Ultra'
+    if spend > 50 and 'VIP' in tier_order:
+        return 'VIP'
+    return tier_order[0] if tier_order else 'Basic'
+
+
+def load_template(tier):
+    mapping = {
+        'Basic': 'welcome_new_sub.txt',
+        'VIP': 'tier1_welcome.md',
+        'Ultra': 'tier1_welcome.md'
+    }
+    filename = mapping.get(tier, 'welcome_new_sub.txt')
+    path = TEMPLATES_DIR / filename
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def personalize(template, user):
+    return template.replace('{{subscriber_name}}', user.get('name', 'there'))
+
+
+def onboard_user(user):
+    rules = load_rules()
+    tiers = load_tiers()
+    segment = assign_segment(user, rules)
+    if segment != 'New':
+        print(f"User {user.get('name')} is not new (segment: {segment}).")
+        return
+    tier = assign_tier(user, tiers)
+    template = load_template(tier)
+    message = personalize(template, user)
+    print(f"Sending {tier} welcome message to {user.get('name')}:")
+    print(message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Onboard a subscriber")
+    parser.add_argument('--name', required=True, help='Subscriber name')
+    parser.add_argument('--days', type=int, default=0, help='Days subscribed')
+    parser.add_argument('--spend', type=float, default=0.0, help='Total spend')
+    args = parser.parse_args()
+
+    user = {'name': args.name, 'days_subscribed': args.days, 'total_spend': args.spend}
+    onboard_user(user)
+
+
+if __name__ == '__main__':
+    main()

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -2,3 +2,4 @@ transformers
 pandas
 matplotlib
 openai
+pyyaml


### PR DESCRIPTION
## Summary
- add simple onboarding workflow for new subscribers
- include PyYAML as a project requirement
- document workflow and location in CRM README

## Testing
- `pytest -q`
- `python 05_crm_subscriber_management/crm/onboarding.py --name Alice --days 0 --spend 60`

------
https://chatgpt.com/codex/tasks/task_e_684dc1f4bc5c8331b63410203310a106