### PR TITLE
Add CRM event processing and retention workflow

### DIFF
--- a/05_crm_subscriber_management/README.md
+++ b/05_crm_subscriber_management/README.md
@@ -9,3 +9,14 @@ This module contains message templates and workflows for subscriber tiers.
 ## Getting Started
 1. Edit or add new templates in `message_templates/`.
 2. Integrate these templates into your CRM automation scripts.
+
+## Example Workflow
+
+Example workflows live under `crm/`:
+
+- `onboarding.py` – welcomes new subscribers using tier definitions.
+- `retention.py` – sends a retention offer to inactive fans.
+- `process_events.py` – reads events from `data/sample_events.json` and
+  triggers the appropriate workflow.
+
+Each script logs messages to `crm_logs.txt` in this module's root.

--- a/05_crm_subscriber_management/crm/db.py
+++ b/05_crm_subscriber_management/crm/db.py
@@ -1,0 +1,32 @@
+"""Simple JSON-based subscriber database."""
+import json
+from pathlib import Path
+
+DB_FILE = Path(__file__).resolve().parents[1] / 'data' / 'subscribers_db.json'
+
+
+def _load():
+    if DB_FILE.exists():
+        with open(DB_FILE, 'r') as f:
+            return json.load(f)
+    return {}
+
+
+def _save(data):
+    DB_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(DB_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def get(user_id):
+    data = _load()
+    return data.get(str(user_id))
+
+
+def update(user_id, info):
+    data = _load()
+    existing = data.get(str(user_id), {})
+    existing.update(info)
+    data[str(user_id)] = existing
+    _save(data)
+    return existing

--- a/05_crm_subscriber_management/crm/messaging.py
+++ b/05_crm_subscriber_management/crm/messaging.py
@@ -1,0 +1,13 @@
+"""Utility to log CRM messages."""
+from pathlib import Path
+
+LOG_FILE = Path(__file__).resolve().parents[1] / 'crm_logs.txt'
+
+
+def send_message(user_name: str, message: str) -> str:
+    """Append a CRM message to the log file and print it."""
+    entry = f"{user_name}: {message}"
+    with open(LOG_FILE, 'a') as f:
+        f.write(entry + "\n")
+    print(entry)
+    return entry

--- a/05_crm_subscriber_management/crm/onboarding.py
+++ b/05_crm_subscriber_management/crm/onboarding.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+import yaml
+import argparse
+
+from . import db, messaging
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+RULES_FILE = BASE_DIR / "segmentation_rules.json"
+TIERS_FILE = BASE_DIR / "tier_definitions.yaml"
+TEMPLATES_DIR = BASE_DIR / "message_templates"
+
+
+def load_rules():
+    with open(RULES_FILE, 'r') as f:
+        data = json.load(f)
+    return data.get('rules', [])
+
+
+def load_tiers():
+    with open(TIERS_FILE, 'r') as f:
+        data = yaml.safe_load(f)
+    return data.get('tiers', [])
+
+
+def parse_condition(value_str, actual):
+    """Evaluate a simple condition like '<7' or '>100'."""
+    if value_str.startswith('<'):
+        return actual < float(value_str[1:])
+    if value_str.startswith('>'):
+        return actual > float(value_str[1:])
+    return str(actual) == str(value_str)
+
+
+def assign_segment(user, rules):
+    for rule in rules:
+        segment = rule.get('segment')
+        conditions = {k: v for k, v in rule.items() if k != 'segment'}
+        matched = True
+        for field, cond in conditions.items():
+            actual = user.get(field)
+            if actual is None or not parse_condition(cond, actual):
+                matched = False
+                break
+        if matched:
+            return segment
+    return 'Unsegmented'
+
+
+def assign_tier(user, tiers):
+    spend = user.get('total_spend', 0)
+    # Simple heuristic using spend; names come from config
+    tier_order = [t['name'] for t in tiers]
+    if spend > 100 and 'Ultra' in tier_order:
+        return 'Ultra'
+    if spend > 50 and 'VIP' in tier_order:
+        return 'VIP'
+    return tier_order[0] if tier_order else 'Basic'
+
+
+def load_template(tier):
+    mapping = {
+        'Basic': 'welcome_new_sub.txt',
+        'VIP': 'tier1_welcome.md',
+        'Ultra': 'tier1_welcome.md'
+    }
+    filename = mapping.get(tier, 'welcome_new_sub.txt')
+    path = TEMPLATES_DIR / filename
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def personalize(template, user):
+    return template.replace('{{subscriber_name}}', user.get('name', 'there'))
+
+
+def onboard_user(user):
+    rules = load_rules()
+    tiers = load_tiers()
+    segment = assign_segment(user, rules)
+    if segment != 'New':
+        print(f"User {user.get('name')} is not new (segment: {segment}).")
+        return None
+    tier = assign_tier(user, tiers)
+    template = load_template(tier)
+    message = personalize(template, user)
+    db.update(user['id'], user)
+    print(f"Sending {tier} welcome message to {user.get('name')}:")
+    return messaging.send_message(user['name'], message)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Onboard a subscriber")
+    parser.add_argument('--id', type=int, default=1, help='Subscriber ID')
+    parser.add_argument('--name', required=True, help='Subscriber name')
+    parser.add_argument('--days', type=int, default=0, help='Days subscribed')
+    parser.add_argument('--spend', type=float, default=0.0, help='Total spend')
+    args = parser.parse_args()
+
+    user = {'id': args.id, 'name': args.name, 'days_subscribed': args.days, 'total_spend': args.spend}
+    onboard_user(user)
+
+
+if __name__ == '__main__':
+    main()

--- a/05_crm_subscriber_management/crm/process_events.py
+++ b/05_crm_subscriber_management/crm/process_events.py
@@ -1,0 +1,31 @@
+"""Process subscriber events and trigger CRM workflows."""
+import json
+from pathlib import Path
+
+from . import db
+from .onboarding import onboard_user
+from .retention import send_retention_offer
+from .messaging import send_message
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+EVENTS_FILE = BASE_DIR / 'data' / 'sample_events.json'
+
+
+def process_events():
+    with open(EVENTS_FILE, 'r') as f:
+        events = json.load(f).get('events', [])
+
+    for event in events:
+        user = event['subscriber']
+        if event['event'] == 'new':
+            onboard_user(user)
+        elif event['event'] == 'inactive':
+            send_retention_offer(user)
+        elif event['event'] == 'upgrade':
+            message = f"Thanks for upgrading! Enjoy your new perks, {user['name']}!"
+            db.update(user['id'], user)
+            send_message(user['name'], message)
+
+
+if __name__ == '__main__':
+    process_events()

--- a/05_crm_subscriber_management/crm/retention.py
+++ b/05_crm_subscriber_management/crm/retention.py
@@ -1,0 +1,39 @@
+"""Send retention offers to inactive subscribers."""
+from pathlib import Path
+
+from . import db, messaging
+from .onboarding import load_rules, assign_segment, personalize
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+TEMPLATES_DIR = BASE_DIR / 'message_templates'
+
+
+def load_retention_template():
+    path = TEMPLATES_DIR / 'retention_offer.md'
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def send_retention_offer(user):
+    """Send a retention message if the user matches the At-Risk segment."""
+    rules = load_rules()
+    segment = assign_segment(user, rules)
+    if segment != 'At-Risk':
+        print(f"User {user.get('name')} is not at risk (segment: {segment}).")
+        return None
+
+    template = load_retention_template()
+    message = personalize(template, user)
+    db.update(user['id'], user)
+    return messaging.send_message(user['name'], message)
+
+
+if __name__ == '__main__':
+    demo_user = {
+        'id': 2,
+        'name': 'Bob',
+        'days_subscribed': 30,
+        'no_activity_days': 15,
+        'total_spend': 10,
+    }
+    send_retention_offer(demo_user)

--- a/05_crm_subscriber_management/data/sample_events.json
+++ b/05_crm_subscriber_management/data/sample_events.json
@@ -1,0 +1,32 @@
+{
+  "events": [
+    {
+      "event": "new",
+      "subscriber": {
+        "id": 1,
+        "name": "Alice",
+        "days_subscribed": 0,
+        "total_spend": 60
+      }
+    },
+    {
+      "event": "inactive",
+      "subscriber": {
+        "id": 2,
+        "name": "Bob",
+        "days_subscribed": 30,
+        "no_activity_days": 15,
+        "total_spend": 10
+      }
+    },
+    {
+      "event": "upgrade",
+      "subscriber": {
+        "id": 1,
+        "name": "Alice",
+        "days_subscribed": 30,
+        "total_spend": 120
+      }
+    }
+  ]
+}

--- a/05_crm_subscriber_management/data/subscribers_db.json
+++ b/05_crm_subscriber_management/data/subscribers_db.json
@@ -1,0 +1,15 @@
+{
+  "3": {
+    "id": 3,
+    "name": "Test",
+    "days_subscribed": 0,
+    "total_spend": 5
+  },
+  "4": {
+    "id": 4,
+    "name": "Old",
+    "days_subscribed": 30,
+    "no_activity_days": 15,
+    "total_spend": 5
+  }
+}

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -2,3 +2,4 @@ transformers
 pandas
 matplotlib
 openai
+pyyaml

--- a/tests/unit/test_crm_workflows.py
+++ b/tests/unit/test_crm_workflows.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / '05_crm_subscriber_management'
+if str(MODULE_PATH) not in sys.path:
+    sys.path.insert(0, str(MODULE_PATH))
+
+from crm import onboarding, retention
+
+
+class TestCRMWorkflows(unittest.TestCase):
+    def test_onboard_and_retention(self):
+        new_user = {'id': 3, 'name': 'Test', 'days_subscribed': 0, 'total_spend': 5}
+        msg1 = onboarding.onboard_user(new_user)
+        self.assertIn('Test', msg1)
+
+        inactive = {'id': 4, 'name': 'Old', 'days_subscribed': 30, 'no_activity_days': 15, 'total_spend': 5}
+        msg2 = retention.send_retention_offer(inactive)
+        self.assertIn('Old', msg2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand README with additional CRM workflow info
- add JSON-backed database helper and message logger
- enhance onboarding workflow and add retention workflow
- implement event processor with sample data
- add unit test for CRM workflows

## Testing
- `pip install -r common/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc1f4bc5c8331b63410203310a106