### PR TITLE
Remove wildcard import in entry_with_update

### DIFF
--- a/08_onlyfans_model/Fooocus-2.5.5/entry_with_update.py
+++ b/08_onlyfans_model/Fooocus-2.5.5/entry_with_update.py
@@ -43,4 +43,4 @@ except Exception as e:
     print(str(e))
 
 print('Update succeeded.')
-from launch import *
+import launch


### PR DESCRIPTION
## Summary
- avoid namespace pollution in `entry_with_update.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684dd97b7fa883319e726d94dbc90e0f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the way a module is imported to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->