### PR TITLE
Resolve merge conflict in retention script

### DIFF
--- a/05_crm_subscriber_management/crm/retention.py
+++ b/05_crm_subscriber_management/crm/retention.py
@@ -1,19 +1,49 @@
-# retention.py
+"""Utilities for re-engaging inactive subscribers."""
 
+from pathlib import Path
+import sys
 from datetime import datetime, timedelta
 from sqlmodel import select
-from db import get_session
-from models import Subscriber, MessageLog
-from email_utils import send_email
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    __package__ = "crm"
+
+from .db import get_session
+from .models import Subscriber, MessageLog
+from .email_utils import send_email
+from .onboarding import personalize
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+TEMPLATES_DIR = BASE_DIR / "message_templates"
+
+def load_retention_template():
+    """Return the retention offer template as text."""
+    path = TEMPLATES_DIR / "retention_offer.md"
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Retention template not found at {path}") from None
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read retention template: {exc}") from exc
+
+def send_retention_offer(sub, session):
+    """Send the retention email to a subscriber and log it."""
+    template = load_retention_template()
+    message = personalize(template, {"name": sub.username})
+    subject = "We miss you on OnlyFans!"
+    resp = send_email(sub.email, subject, message)
+    log = MessageLog(subscriber_id=sub.id, message="Retention email sent.")
+    session.add(log)
+    session.commit()
+    return resp
 
 def run_retention():
-    """
-    Finds subscribers whose last_active is more than 7 days ago,
-    sends them a re-engagement email, and logs the message.
-    """
+    """Send retention offers to subscribers inactive for over a week."""
     session = get_session()
     cutoff = datetime.utcnow() - timedelta(days=7)
-    # Select inactive subscribers
+
     stmt = select(Subscriber).where(
         Subscriber.last_active != None,
         Subscriber.last_active < cutoff
@@ -21,19 +51,11 @@ def run_retention():
     inactive_subs = session.exec(stmt).all()
 
     for sub in inactive_subs:
-        subject = "We miss you on OnlyFans!"
-        content = (
-            f"Hi {sub.username},\n\n"
-            "It's been a while since we've seen you. "
-            "Check out our latest content and come say hi!\n\n"
-            "– Your OnlyFans Team"
-        )
         try:
-            resp = send_email(sub.email, subject, content)
-            # Log success
-            log = MessageLog(subscriber_id=sub.id, message=f"Retention email sent.")
-            session.add(log)
-            session.commit()
+            send_retention_offer(sub, session)
             print(f"[{datetime.utcnow()}] Email sent to {sub.email}")
         except Exception as e:
             print(f"[{datetime.utcnow()}] Failed to send to {sub.email}: {str(e)}")
+
+if __name__ == "__main__":
+    run_retention()


### PR DESCRIPTION
## Summary
- merge features from CRM expansion into retention script
- load retention offer templates
- send personalized retention emails and log them

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684ddd74c79483318a83abb45c107e84