### PR TITLE
Implement churn workflow and DB-backed segmentation

### DIFF
--- a/05_crm_subscriber_management/README.md
+++ b/05_crm_subscriber_management/README.md
@@ -18,11 +18,14 @@ This module contains message templates and workflows for subscriber tiers.
 
 Example workflows live under `crm/`:
 
-- `onboarding.py` – loads segmentation rules and tier definitions to send a welcome message.
-- `retention.py` – sends a retention offer to inactive fans.
+- `onboarding.py` – sends the initial welcome and records the subscriber in the database.
+- `retention.py` – emails a retention offer to inactive fans.
+- `churn.py` – marks long inactive subscribers as churned and sends a final message.
 - `process_events.py` – reads events from `data/sample_events.json` and triggers the appropriate workflow.
 
 Each script logs messages to `crm_logs.txt` in this module's root. `process_events.py` also accepts a custom events file via `--file <path>`.
+
+The `scheduler.py` module runs retention checks daily and churn checks weekly.
 
 ### Running Scripts
 

--- a/05_crm_subscriber_management/crm/churn.py
+++ b/05_crm_subscriber_management/crm/churn.py
@@ -1,0 +1,51 @@
+"""Send churn warning emails to long inactive subscribers."""
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from sqlmodel import select
+
+from .db import get_session
+from .models import Subscriber, MessageLog
+from .email_utils import send_email
+from .onboarding import personalize
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+TEMPLATES_DIR = BASE_DIR / "message_templates"
+
+
+def load_churn_template():
+    path = TEMPLATES_DIR / "churn_warning_followup.txt"
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def send_churn_warning(sub, session):
+    template = load_churn_template()
+    message = personalize(template, {"name": sub.username})
+    send_email(sub.email, "We're sorry to see you go", message)
+    sub.is_active = False
+    session.add(sub)
+    session.add(MessageLog(subscriber_id=sub.id, message="Churn warning sent"))
+    session.commit()
+
+
+def run_churn():
+    """Send churn warnings to subscribers inactive for over 30 days."""
+    session = get_session()
+    cutoff = datetime.utcnow() - timedelta(days=30)
+    stmt = select(Subscriber).where(
+        Subscriber.last_active != None,
+        Subscriber.last_active < cutoff,
+        Subscriber.is_active == True,
+    )
+    subs = session.exec(stmt).all()
+    for sub in subs:
+        try:
+            send_churn_warning(sub, session)
+            print(f"Churn warning sent to {sub.email}")
+        except Exception as exc:
+            print(f"Failed to send to {sub.email}: {exc}")
+
+
+if __name__ == "__main__":
+    run_churn()

--- a/05_crm_subscriber_management/crm/models.py
+++ b/05_crm_subscriber_management/crm/models.py
@@ -1,4 +1,6 @@
-from typing import Optional, List
+"""SQLModel definitions for the CRM database."""
+
+from typing import Optional
 from sqlmodel import SQLModel, Field
 from datetime import datetime
 
@@ -18,3 +20,19 @@ class MessageLog(SQLModel, table=True):
     subscriber_id: int = Field(foreign_key="subscriber.id")
     sent_at: datetime = Field(default_factory=datetime.utcnow)
     message: str
+
+
+class SegmentRule(SQLModel, table=True):
+    """Segmentation rule stored as JSON."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    segment: str
+    rule_json: str
+
+
+class TierDefinition(SQLModel, table=True):
+    """Subscriber tier definition stored in the DB."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    criteria: str

--- a/05_crm_subscriber_management/crm/onboarding.py
+++ b/05_crm_subscriber_management/crm/onboarding.py
@@ -1,7 +1,14 @@
+"""Onboarding workflow for new subscribers."""
+
 import json
 from pathlib import Path
 import yaml
 import argparse
+from datetime import datetime
+from sqlmodel import select
+
+from .db import get_session, get_segment_rules, get_tier_definitions
+from .models import Subscriber, MessageLog
 
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -11,15 +18,23 @@ TEMPLATES_DIR = BASE_DIR / "message_templates"
 
 
 def load_rules():
-    with open(RULES_FILE, 'r') as f:
-        data = json.load(f)
-    return data.get('rules', [])
+    """Load segmentation rules from the DB, falling back to JSON."""
+    try:
+        return get_segment_rules()
+    except Exception:
+        with open(RULES_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return data.get('rules', [])
 
 
 def load_tiers():
-    with open(TIERS_FILE, 'r') as f:
-        data = yaml.safe_load(f)
-    return data.get('tiers', [])
+    """Load tier definitions from the DB, falling back to YAML."""
+    try:
+        return get_tier_definitions()
+    except Exception:
+        with open(TIERS_FILE, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        return data.get('tiers', [])
 
 
 def parse_condition(value_str, actual):
@@ -80,9 +95,29 @@ def onboard_user(user):
     if segment != 'New':
         print(f"User {user.get('name')} is not new (segment: {segment}).")
         return
+
     tier = assign_tier(user, tiers)
     template = load_template(tier)
     message = personalize(template, user)
+
+    with get_session() as session:
+        sub = session.exec(select(Subscriber).where(Subscriber.username == user['name'])).first()
+        if not sub:
+            sub = Subscriber(username=user['name'], email=user.get('email', ''), tier=tier, tags=segment, last_active=datetime.utcnow())
+            session.add(sub)
+            session.commit()
+            session.refresh(sub)
+        else:
+            sub.tier = tier
+            sub.tags = segment
+            sub.last_active = datetime.utcnow()
+            session.add(sub)
+            session.commit()
+
+        log = MessageLog(subscriber_id=sub.id, message="Onboarding welcome sent")
+        session.add(log)
+        session.commit()
+
     print(f"Sending {tier} welcome message to {user.get('name')}:")
     print(message)
 

--- a/05_crm_subscriber_management/crm/process_events.py
+++ b/05_crm_subscriber_management/crm/process_events.py
@@ -1,0 +1,40 @@
+"""Process sample CRM events and trigger workflows."""
+
+import json
+from pathlib import Path
+import argparse
+
+from onboarding import onboard_user
+from retention import run_retention
+from churn import run_churn
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "data"
+
+
+def load_events(path: Path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def process_events(events):
+    for event in events:
+        etype = event.get("type")
+        if etype == "new_subscription":
+            onboard_user(event)
+        elif etype == "inactivity":
+            run_retention()
+        elif etype == "churn_check":
+            run_churn()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", type=Path, default=DATA_DIR / "sample_events.json")
+    args = parser.parse_args()
+    events = load_events(args.file)
+    process_events(events)
+
+
+if __name__ == "__main__":
+    main()

--- a/05_crm_subscriber_management/crm/scheduler.py
+++ b/05_crm_subscriber_management/crm/scheduler.py
@@ -2,6 +2,7 @@
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from retention import run_retention
+from churn import run_churn
 
 def main():
     scheduler = BlockingScheduler(timezone="UTC")
@@ -12,6 +13,15 @@ def main():
         hour=0,
         minute=0,
         id="daily_retention"
+    )
+    # Run churn checks weekly on Mondays at 01:00 UTC
+    scheduler.add_job(
+        run_churn,
+        trigger="cron",
+        day_of_week="mon",
+        hour=1,
+        minute=0,
+        id="weekly_churn",
     )
     print("Starting retention scheduler (daily at 00:00 UTC)...")
     scheduler.start()

--- a/05_crm_subscriber_management/data/sample_events.json
+++ b/05_crm_subscriber_management/data/sample_events.json
@@ -1,0 +1,5 @@
+[
+  {"type": "new_subscription", "name": "Alice", "email": "alice@example.com", "days_subscribed": 0, "total_spend": 0},
+  {"type": "inactivity"},
+  {"type": "churn_check"}
+]

--- a/tests/test_crm_templates_exist.py
+++ b/tests/test_crm_templates_exist.py
@@ -6,7 +6,8 @@ def test_crm_templates_exist():
         'inactivity_7day_drip.txt',
         'vip_upsell_offer.txt',
         'milestone_celebration.txt',
-        'renewal_reminder.txt'
+        'renewal_reminder.txt',
+        'churn_warning_followup.txt'
     ]
     base = '05_crm_subscriber_management/message_templates'
     for t in templates:

--- a/tests/test_segmentation_db.py
+++ b/tests/test_segmentation_db.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CRM_PATH = ROOT / '05_crm_subscriber_management' / 'crm'
+if str(CRM_PATH) not in sys.path:
+    sys.path.insert(0, str(CRM_PATH))
+
+from db import init_db, get_session, get_segment_rules
+from models import SegmentRule
+from sqlmodel import select
+
+
+def test_segment_rules_loaded(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/test.db')
+    init_db()
+    rules = get_segment_rules()
+    with get_session() as session:
+        db_rules = session.exec(select(SegmentRule)).all()
+    assert len(db_rules) == len(rules)


### PR DESCRIPTION
## Summary
- add churn notification workflow and update scheduler
- store segmentation rules and tier definitions in the database
- update onboarding flow to persist subscribers
- document new workflows in CRM README
- test segmentation DB initialization and template files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e0be572788331b05b693dc1ef9dd0