### PR TITLE
Fix path resolution in automation service tests

### DIFF
--- a/03_scheduling_automation/browser_automation_service/backend/apply-schema.js
+++ b/03_scheduling_automation/browser_automation_service/backend/apply-schema.js
@@ -10,8 +10,16 @@ import {
 
 (async () => {
   try {
-    // Initialize SQL.js database in the current directory
-    await createDbConnection(path.resolve('logs.db'));
+    // Resolve the SQLite DB path relative to this file so tests can run from
+    // any working directory. This avoids creating the database in whatever
+    // directory the script was invoked from.
+    const dbFile = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'logs.db'
+    );
+
+    // Initialize SQL.js database using the resolved absolute path
+    await createDbConnection(dbFile);
 
     // Read the schema SQL
     const schemaPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'schema.sql');

--- a/03_scheduling_automation/browser_automation_service/backend/test-apply-schema.js
+++ b/03_scheduling_automation/browser_automation_service/backend/test-apply-schema.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const script = resolve(__dirname, 'apply-schema.js');
+const dbFile = resolve(__dirname, 'logs.db');
 
 // Run apply-schema.js from this backend directory regardless of CWD
 exec(`node ${script}`, (err, stdout, stderr) => {
@@ -14,8 +15,8 @@ exec(`node ${script}`, (err, stdout, stderr) => {
   }
   console.log('Apply-schema output:', stdout);
 
-  // Verify via sqlite3 CLI:
-  exec("sqlite3 logs.db \".tables\"", (err2, out2) => {
+  // Verify via sqlite3 CLI using the same db path:
+  exec(`sqlite3 ${dbFile} \".tables\"`, (err2, out2) => {
     if (err2) {
       console.error('Listing tables failed:', err2);
       process.exit(1);


### PR DESCRIPTION
## Summary
- resolve `logs.db` relative to the backend folder
- ensure test script uses absolute paths for DB

## Testing
- `npm run test --prefix 03_scheduling_automation/browser_automation_service --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e0ebb89dc8331bf4c09ca63e8f8d9