### PR TITLE
Project cleanup and env handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Node modules
 node_modules/
+**/package-lock.json
+!/package-lock.json
 
 # Python cache and compiled files
 __pycache__/

--- a/04_content_generation/pipeline_prototype/prompt_to_image.py
+++ b/04_content_generation/pipeline_prototype/prompt_to_image.py
@@ -10,8 +10,9 @@ from dotenv import load_dotenv
 import smtplib
 from email.mime.text import MIMEText
 
-# Load environment variables from .env file (adjust the path as needed)
-load_dotenv(dotenv_path="G:/Other computers/My Laptop/GitHub/OF-Management-Ai/04_content_generation/.env")
+# Load environment variables from a .env file located next to this script
+ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(dotenv_path=ENV_PATH)
 
 
 import sys

--- a/05_crm_subscriber_management/README.md
+++ b/05_crm_subscriber_management/README.md
@@ -7,10 +7,6 @@
 - Redis-powered async message queue
 - Message log saved to `logs/message_log.jsonl`
 
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
 ## Structure
 - `message_templates/` - Text or Markdown templates for subscriber outreach.
 - `tier_definitions.yaml` - Tier names and criteria.
@@ -20,13 +16,10 @@
 2. Integrate these templates into your CRM automation scripts.
 3. Configure the database:
    - By default `crm/db.py` uses an SQLite file `crm.db`.
-   - Set the `DATABASE_URL` environment variable to connect to Postgres or
-     specify `json` to use a simple JSON file store for quick testing.
+   - Set the `DATABASE_URL` environment variable to connect to Postgres or specify `json` to use a simple JSON file store for quick testing.
 
 ## Example Workflow
-
 Example workflows live under `crm/`:
-
 - `onboarding.py` – sends the initial welcome and records the subscriber in the database.
 - `retention.py` – emails a retention offer to inactive fans.
 - `churn.py` – marks long inactive subscribers as churned and sends a final message.
@@ -37,20 +30,7 @@ Each script logs messages to `crm_logs.txt` in this module's root. `process_even
 The `scheduler.py` module runs retention checks daily and churn checks weekly.
 
 ### Running Scripts
-
 You can execute the workflows directly, for example:
-=======
-## To Run
->>>>>>> Stashed changes
-=======
-## To Run
->>>>>>> Stashed changes
-=======
-## To Run
->>>>>>> Stashed changes
-=======
-## To Run
->>>>>>> Stashed changes
 
 1. **Start Flask API**
 ```bash
@@ -69,3 +49,4 @@ python queue/worker.py
 ```
 
 Make sure Redis is running locally on port 6379.
+


### PR DESCRIPTION
## Summary
- fix merge conflict artifacts in CRM README
- load pipeline env vars from local `.env`
- ignore submodule `package-lock.json` files

## Testing
- `bash run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685844c78e4483319709e748aa625ec1